### PR TITLE
Mark command parameter required if there is no fallback

### DIFF
--- a/nomnom.js
+++ b/nomnom.js
@@ -153,6 +153,8 @@ ArgParser.prototype = {
           if (this.fallback) {
             _(this.specs).extend(this.fallback.specs);
             this._help = this.fallback.help;         
+          } else {
+            this.specs.command.required = true;
           }
        }
     }


### PR DESCRIPTION
This change results in:
- The "command" parameter being shown as `<required>` rather than
  `[optional]` when there is no fallback set with .nocommand()
- It being an error (thus showing help) if no command is passed when
  one is expected, and there is no fallback set with .nocommand()
