### PR TITLE
Allow required unmatched positional arguments

### DIFF
--- a/nomnom.js
+++ b/nomnom.js
@@ -5,6 +5,7 @@ var _ = require("underscore")._,
 function ArgParser() {
    this.commands = {};  // expected commands
    this.specs = {};     // option specifications
+   this.positional_spec = {}; // specification for positional arguments
 }
 
 ArgParser.prototype = {
@@ -74,6 +75,11 @@ ArgParser.prototype = {
   
   option : function(name, spec) {
     this.specs[name] = spec;
+    return this;
+  },
+
+  positionals : function(spec) {
+    this.positional_spec = spec;
     return this;
   },
 
@@ -244,8 +250,16 @@ ArgParser.prototype = {
       this.setOption(options, index, pos);
     }, this);
     
+    if (this.positional_spec.required && positionals.length == 0) {
+      if (this.positional_spec.help) {
+        this.print(this.positional_spec.help + "\n" + this.getUsage(), 1);
+      } else {
+        this.print("At least one positional argument is required\n" + this.getUsage(), 1);
+      }
+    }
+
     options._ = positionals;
-    
+
     this.specs.forEach(function(opt) {
       if (opt.default !== undefined && options[opt.name] === undefined) {
         options[opt.name] = opt.default;
@@ -327,6 +341,10 @@ ArgParser.prototype = {
         str += " [options]";
       }
     }
+
+    if (this.positional_spec.required) {
+      str += " <" + this.positional_spec.name + ">...";
+    };
     
     if (options.length || positionals.length) {
       str += "\n\n";

--- a/test/expected.js
+++ b/test/expected.js
@@ -57,3 +57,20 @@ exports.testChoices = function(test) {
    test.equal(options.color, 'green');
    test.done();
 }
+
+exports.testPositionalArgumentsRequired = function(test) {
+   test.expect(2);
+   var help = "something about positionals being required";
+
+   var parser = nomnom().positionals({
+     required: true, help: help, name: "foobarpositionals"
+   })
+   .printer(function(string) {
+      test.equal(0, string.indexOf(help))
+      test.ok(string.indexOf("<foobarpositionals>..." > 0));
+   });
+
+   parser.parse([]);
+
+   test.done();
+}


### PR DESCRIPTION
Hello!

I have really been enjoying using nomnom, but I have found a use case I was unable to perform.  I wanted to allow the user to specify a command, and have a trailing list of unmatched positional arguments, but at least one was required.

The problem therein was that, it is not possible to specify positional arguments that behave this way, as I do not know before hand the index at which they will begin.

I am not sure if this is something you want to pull in, but I think others could find it useful, e.g. as a workaround for https://github.com/harthur/nomnom/issues/12 .  I tried to follow your code conventions, but please let me know if this pull request needs any work - if you decide to pull it in I can document this feature in the README.

Thanks!
