### PR TITLE
If values contain spaces, treat them as values

### DIFF
--- a/nomnom.js
+++ b/nomnom.js
@@ -487,7 +487,7 @@ ArgParser.prototype.setOption = function(options, arg, value) {
 Arg = function(str) {
   var abbrRegex = /^\-(\w+?)$/,
       fullRegex = /^\-\-(no\-)?(.+?)(?:=(.+))?$/,
-      valRegex = /^[^\-].*/;
+      valRegex = /\s|^[^\-].*/;
 
   var charMatch = abbrRegex.exec(str),
       chars = charMatch && charMatch[1].split("");

--- a/test/values.js
+++ b/test/values.js
@@ -72,4 +72,9 @@ exports.testTypes = function(test) {
    test.done();
 }
 
+exports.testValues = function(test) {
+   var options = parser.parseArgs(["--num1", "-4 4"]);
 
+   test.strictEqual(options.num1, "-4 4");
+   test.done();
+}


### PR DESCRIPTION
Option names should never contain spaces; values might.

This (partially) works around #37, but still prevents individual negative values from being treated as values.
