### PR TITLE
Treat negative numbers and dashes as values

### DIFF
--- a/nomnom.js
+++ b/nomnom.js
@@ -485,9 +485,9 @@ ArgParser.prototype.setOption = function(options, arg, value) {
 /* an arg is an item that's actually parsed from the command line
    e.g. "-l", "log.txt", or "--logfile=log.txt" */
 var Arg = function(str) {
-  var abbrRegex = /^\-(\w+?)$/,
+  var abbrRegex = /^\-([a-zA-Z]+?)$/,
       fullRegex = /^\-\-(no\-)?(.+?)(?:=(.+))?$/,
-      valRegex = /^[^\-].*/;
+      valRegex = /^[^\-].*|^\-[\d.]*$/;
 
   var charMatch = abbrRegex.exec(str),
       chars = charMatch && charMatch[1].split("");

--- a/test/values.js
+++ b/test/values.js
@@ -44,7 +44,7 @@ exports.testFlag = function(test) {
 exports.testList = function(test) {
    var options = parser.parse(["pos0", "pos1", "--list1=val0", "--list2", "val1",
      "--list2", "val2", "pos2"]);
-  
+
    test.deepEqual(options.list1, ["val0"]);
    test.deepEqual(options.list2, ["val1", "val2"]);
    test.deepEqual(options.list3, ["pos1", "pos2"]);
@@ -63,7 +63,7 @@ exports.testDefault = function(test) {
 exports.testTypes = function(test) {
    var options = parser.parseArgs(["", "-x", "3.14", "-w", "true", "-q", "120",
      "--num1", "4"]);
-     
+
    test.strictEqual(options[0], "");
    test.strictEqual(options.x, 3.14);
    test.strictEqual(options.w, true);
@@ -72,4 +72,16 @@ exports.testTypes = function(test) {
    test.done();
 }
 
+exports.testDash = function(test) {
+  var options = parser.parseArgs(['--num1', '-']);
 
+  test.strictEqual(options.num1, '-');
+  test.done();
+};
+
+exports.testNumbers = function(test) {
+  var options = parser.parseArgs(['sum', '-1', '2.5', '-3.5', '4']);
+
+  test.deepEqual(options.list3, ['-1', '2.5', '-3.5', '4']);
+  test.done();
+};


### PR DESCRIPTION
Why is it a good idea?
- `-` is a special argument across multiple Unix commands and usually stands for stdin (`echo hello |cat - /another/file`);
- negative numbers are not usually expected to behave as options, but rather as values, this is also sort of a standard (`echo -e 'hello\nworld' |head -1`);
- I doubt there exists a single program which defines an option with spaces in it.

This patch is a superset of #38.
