### PR TITLE
do not error on unspecified flags

### DIFF
--- a/nomnom.js
+++ b/nomnom.js
@@ -239,7 +239,7 @@ ArgParser.prototype = {
               that.setOption(options, last, val.value);
               return Arg(); // skip next turn - swallow arg
            }
-           else {
+           else if (that.exists(last)) {
               that.print("'-" + (that.opt(last).name || last) + "'"
                 + " expects a value\n\n" + that.getUsage(), 1);
            }
@@ -261,7 +261,7 @@ ArgParser.prototype = {
               that.setOption(options, arg.full, val.value);
               return Arg();
             }
-            else {
+            else if (that.exists(arg.full)) {
               that.print("'--" + (that.opt(arg.full).name || arg.full) + "'"
                 + " expects a value\n\n" + that.getUsage(), 1);
             }
@@ -439,6 +439,12 @@ ArgParser.prototype.opt = function(arg) {
     }
   });
   return match;
+};
+
+ArgParser.prototype.exists = function(arg) {
+  return _.any(this.specs, function(opt) {
+    return opt.matches(arg);
+  });
 };
 
 ArgParser.prototype.setOption = function(options, arg, value) {

--- a/test/expected.js
+++ b/test/expected.js
@@ -12,9 +12,18 @@ var parser = nomnom().options(opts);
 exports.testFlag = function(test) {
    test.expect(1);
 
-   nomnom().options({
-      file: {
-         position: 0,
+   var options = nomnom().parse(["--key1"]);
+
+   test.equal(options.key1, undefined);
+   test.done();
+}
+
+exports.testExists = function(test) {
+   test.expect(1);
+
+   var options = nomnom().options({
+      key1: {
+         position: 0
       }
    })
    .printer(function(string) {


### PR DESCRIPTION
We are trying to use nomnom in gulp 4.0, but we've always supported passing flags gulp doesn't use along to the gulpfile for users to switch on, etc.  Someone opened https://github.com/gulpjs/gulp/issues/780 and I confirmed that an unspecified flag shows the error message.  This change makes the current behavior work for specified flags and doesn't error on unspecified flags.