### PR TITLE
Hide empty options in usage output

### DIFF
--- a/nomnom.js
+++ b/nomnom.js
@@ -338,6 +338,9 @@ ArgParser.prototype = {
     var options = _(this.specs).select(function(opt) {
       return opt.position === undefined;
     });
+    var showOptions = _(options).reject(function(opt) {
+      return opt.hidden;
+    }).toString();
 
     // assume there are no gaps in the specified pos. args
     positionals.forEach(function(pos) {
@@ -357,7 +360,7 @@ ArgParser.prototype = {
       str += posStr;
     });
 
-    if (options.length) {
+    if (showOptions) {
       if (!this._nocolors) {
         // must be a better way to do this
         str += chalk.blue(" [options]");
@@ -367,7 +370,7 @@ ArgParser.prototype = {
       }
     }
 
-    if (options.length || positionals.length) {
+    if (showOptions || positionals.length) {
       str += "\n\n";
     }
 
@@ -393,11 +396,11 @@ ArgParser.prototype = {
       }
       str += "\n";
     }, this);
-    if (positionals.length && options.length) {
+    if (positionals.length && showOptions) {
       str += "\n";
     }
 
-    if (options.length) {
+    if (showOptions) {
       if (!this._nocolors) {
         str += chalk.blue("Options:");
       }

--- a/test/usage.js
+++ b/test/usage.js
@@ -90,7 +90,7 @@ exports.testHidden = function(test) {
    })
    .scriptName("test")
    .printer(function(string) {
-      test.equal(strip("Usage:test[options]Options:"), strip(string))
+      test.equal(strip("Usage:test"), strip(string))
       test.done();
    })
    .nocolors()


### PR DESCRIPTION
If you only specify options that are all set at `hidden: true` then the usage output will still display the empty options list.

## Current behavior:
```sh
$ cli -h

Usage: cli <command> [options]

command
  foo       bar
  baz      foo

Options:

```

## Fixed output:
```sh
$ cli -h

Usage: cli <command>

command
  foo       bar
  baz      foo

```

----

I edited the test that was currently expecting that empty options list, but it's just not very clean to add the options list if none of the options are shown. Seem weird.
