### PR TITLE
Use console.error when a non-zero exit code is used

### DIFF
--- a/nomnom.js
+++ b/nomnom.js
@@ -122,8 +122,13 @@ ArgParser.prototype = {
 
   parse : function(argv) {
     this.print = this.print || function(str, code) {
-      console.log(str);
-      process.exit(code || 0);
+      if (code > 0) {
+        console.error(str);
+        process.exit(code);
+      } else {
+        console.log(str);
+        process.exit(0);
+      }
     };
     this._help = this._help || "";
     this._script = this._script || process.argv[0] + " "


### PR DESCRIPTION
When a CLI tool using nomnom is hooked up to write to stdout, it's problematic if console.log is used to report usage errors, as the error message would then be written to stdout instead of stderr.

This commit makes it use console.error instead for non-zero exit codes, which fixes our use case.