### PR TITLE
Adding color overrides.

### DIFF
--- a/examples/colorOverride.js
+++ b/examples/colorOverride.js
@@ -1,0 +1,34 @@
+var chalk = require('chalk');
+
+var parser = require("../nomnom")
+    .script("runtests")
+    .setColors({
+        usageHeadingColor: chalk.green,
+        usageStringColor: chalk.bgCyan,
+        positionalHelpColor: chalk.red,
+        optionsHeaderColor: chalk.cyan,
+        helpColor: chalk.bgCyan,
+        requiredArgColor: chalk.magenta
+    })
+    .options({
+        path: {
+            position: 0,
+            help: "Test file to run",
+            list: true
+        },
+        config: {
+            abbr: 'c',
+            metavar: 'FILE',
+            help: "Config file with tests to run"
+        },
+        debug: {
+            abbr: 'd',
+            flag: true,
+            help: "Print debugging info"
+        }
+    });
+
+
+var opts = parser.parse();
+
+console.log('\nopts:\n', JSON.stringify(opts, undefined, 4));

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,0 +1,24 @@
+var parser = require("../nomnom")
+    .script("runtests")
+    .options({
+        path: {
+            position: 0,
+            help: "Test file to run",
+            list: true
+        },
+        config: {
+            abbr: 'c',
+            metavar: 'FILE',
+            help: "Config file with tests to run"
+        },
+        debug: {
+            abbr: 'd',
+            flag: true,
+            help: "Print debugging info"
+        }
+    });
+
+
+var opts = parser.parse();
+
+console.log('\nopts:\n', JSON.stringify(opts, undefined, 4));

--- a/test/usage.js
+++ b/test/usage.js
@@ -36,6 +36,8 @@ exports.testH = function(test) {
    test.expect(1);
 
    parser.printer(function(string) {
+      console.log('\n EXPECTED: ', expected);
+      console.log('\n   ACTUAL: ', strip(string));
       test.equal(strip(string), expected)
       test.done();
    })


### PR DESCRIPTION
Hey Heather,
This PR does two things:
1. Allows config of colors for different output (errors, options, etc..). Probably not the best break down, but it keeps it consistent. Would like to switch to something other than chalk (more options).

2. Changes default windows color (blue isn't readable on windows).

If you like, we can iterate on the configuration of colors (add/subtracting different 'usages').

Let me know what you think.