### PR TITLE
Call `transform` even for default options

### DIFF
--- a/nomnom.js
+++ b/nomnom.js
@@ -288,7 +288,7 @@ ArgParser.prototype = {
         if (typeof opt.transform === 'function') {
           optValue = opt.transform(optValue);
         }
-        options[opt.name] = defaultValue;
+        options[opt.name] = optValue;
 
       }
     }, this);

--- a/nomnom.js
+++ b/nomnom.js
@@ -284,7 +284,12 @@ ArgParser.prototype = {
 
     this.specs.forEach(function(opt) {
       if (opt.default !== undefined && options[opt.name] === undefined) {
-        options[opt.name] = opt.default;
+        var optValue = opt.default;
+        if (typeof opt.transform === 'function') {
+          optValue = opt.transform(optValue);
+        }
+        options[opt.name] = defaultValue;
+
       }
     }, this);
 


### PR DESCRIPTION
Currently, the `transform` option isn't called for default options. Made one of my projects cleaner to have this ability.
