### PR TITLE
relax underscore version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "parser"
   ],
   "dependencies": {
-    "underscore": "~1.6.0",
+    "underscore": "1.6 - 1.8",
     "chalk": "~0.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Underscore tends to introduce breaking changes in minor versions, so we
probably don't want to accept 1.x, but everything up to 1.8 (the latest)
works fine.
