### PR TITLE
Bump chalk version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "dependencies": {
     "underscore": "~1.6.0",
-    "chalk": "~0.4.0"
+    "chalk": "~1.1.1"
   },
   "devDependencies": {
     "nodeunit": "~0.7.4"


### PR DESCRIPTION
to prevent npm warning about `has-color` renaming.
