### PR TITLE
Adding license info to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "nomnom",
   "description": "Option parser with generated usage and commands",
   "version": "1.8.1",
+  "license": "MIT",
   "author": "Heather Arthur <fayearthur@gmail.com>",
   "scripts": {
     "test": "./node_modules/.bin/nodeunit test/*.js"


### PR DESCRIPTION
I'm working on the open source project VersionEye. By adding to the license info to the package.json it's much easier for OS tools to read out the license info and that way the license info is available through the public NPMRegistry API.