### PR TITLE
No license information on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,6 @@
   },
   "devDependencies": {
     "nodeunit": "~0.7.4"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
This would create a conflict between what Github says about license, and what NPM says about license.